### PR TITLE
feat: add BSC network configs

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -13,6 +13,15 @@ const config: HardhatUserConfig = {
     target: {
       url: process.env.TARGET_RPC_URL || "",
     },
+    bsc: {
+      url: process.env.BSC_RPC_URL || "https://bsc-dataseed.binance.org",
+      chainId: 56,
+    },
+    bscTestnet: {
+      url:
+        process.env.BSC_TESTNET_RPC_URL || "https://bsc-testnet-rpc.publicnode.com",
+      chainId: 97,
+    },
   },
 };
 


### PR DESCRIPTION
## Summary
- add BSC mainnet and testnet configs to Hardhat with env-based RPC URLs

## Testing
- `npx hardhat compile --network bsc`
- `npx hardhat compile --network bscTestnet`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aac7b6f104832488a093944bfdfe30